### PR TITLE
Add "Include Legend" checkbox

### DIFF
--- a/app/Livewire/CreateCode.php
+++ b/app/Livewire/CreateCode.php
@@ -7,6 +7,8 @@ use Livewire\Component;
 
 class CreateCode extends Component
 {
+    public bool $includeLegend = true;
+
     public string $message;
 
     protected array $symbols = [

--- a/resources/views/components/legend.blade.php
+++ b/resources/views/components/legend.blade.php
@@ -1,8 +1,12 @@
-@props(['letters'])
+@props(['letters', 'includeLegend' => true])
 
 <div class="flex flex-wrap mt-auto">
     @foreach ($letters as $letter => $symbol)
-        <div class="flex flex-col items-center border border-white/10 print:border-gray-400 p-2">
+        <div 
+            @class([
+                'flex flex-col items-center border border-white/10 print:border-gray-400 p-2',
+                'print:hidden' => ! $includeLegend,
+            ])>
             <span class="mb-2 font-bold">{{ ucwords($letter) }}</span>
             <span class="material-symbols-outlined character">{{ $symbol }}</span>
         </div>

--- a/resources/views/livewire/create-code.blade.php
+++ b/resources/views/livewire/create-code.blade.php
@@ -4,6 +4,10 @@
                   class="bg-white/10 text-white py-2 px-3 rounded-xl w-full"></textarea>
 
         <div class="mt-2 flex justify-end">
+            <div class="flex items-center mr-3">
+                <input type="checkbox" wire:model.live="includeLegend" class="mr-2 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-600 ring-offset-gray-800 focus:ring-2" @disabled(! $message)>
+                <label for="includeLegend">Include Legend</label>
+            </div>
             <button type="button" @disabled(! $message) @click="window.print()" class="bg-blue-500 px-4 py-1 text-sm font-semibold rounded-md disabled:bg-gray-300">Print</button>
         </div>
     </form>
@@ -11,6 +15,6 @@
     <x-code :message="$message" :letters="$this->letters"/>
 
     @if ($message)
-        <x-legend :letters="$this->letters" />
+        <x-legend :letters="$this->letters" :includeLegend="$includeLegend" />
     @endif
 </div>


### PR DESCRIPTION
This PR introduces a "Include Legend" checkbox, which is enabled by default. This feature will allow users to choose whether they want to include the legend in the print output, offering an option for added difficulty.

<img width="1044" alt="Screenshot 2023-11-04 at 10 45 28 PM" src="https://github.com/laracasts/codebreaker/assets/17038330/319a4443-f03f-46c5-85fe-5e2e62a85da8">

<img width="1260" alt="Screenshot 2023-11-04 at 10 45 45 PM" src="https://github.com/laracasts/codebreaker/assets/17038330/d25a0cc0-cbc9-4a40-a45d-9e98e9ee0dbf">


<img width="647" alt="Screenshot 2023-11-04 at 10 46 01 PM" src="https://github.com/laracasts/codebreaker/assets/17038330/484da22a-6cf4-4d63-946d-a80f054eb0ad">


