### PR TITLE
Layout improvement: under symbols there is no need for the gray square area

### DIFF
--- a/resources/views/components/code.blade.php
+++ b/resources/views/components/code.blade.php
@@ -12,7 +12,9 @@
                         {{ $letters[strtolower($character)] ?? $character }}
                     </span>
 
-                    <div class="bg-gray-200 w-12 h-12"></div>
+                    @if(preg_match("/[a-z]/i", $character))
+                        <div class="bg-gray-200 w-12 h-12"></div>
+                    @endif
                 </div>
             @endforeach
         </div>

--- a/resources/views/components/code.blade.php
+++ b/resources/views/components/code.blade.php
@@ -12,11 +12,12 @@
                         {{ $letters[strtolower($character)] ?? $character }}
                     </span>
 
-                    <div class="
-                    @if(preg_match("/[a-z]/i", $character))
-                        bg-gray-200
-                    @endif
-                         w-12 h-12"></div>
+                    <div 
+                        @class([
+                            'w-12 h-12',
+                            'bg-gray-200' => preg_match("/[a-z]/i", $character),
+                        ])
+                    ></div>
                 </div>
             @endforeach
         </div>

--- a/resources/views/components/code.blade.php
+++ b/resources/views/components/code.blade.php
@@ -12,9 +12,11 @@
                         {{ $letters[strtolower($character)] ?? $character }}
                     </span>
 
+                    <div class="
                     @if(preg_match("/[a-z]/i", $character))
-                        <div class="bg-gray-200 w-12 h-12"></div>
+                        bg-gray-200
                     @endif
+                         w-12 h-12"></div>
                 </div>
             @endforeach
         </div>


### PR DESCRIPTION
On code component there is no need to show the bottom square under symbols.

![Screenshot 2023-11-20 alle 08 24 10](https://github.com/laracasts/codebreaker/assets/89445565/9e12dab1-b673-4d60-89bf-9659b810732a)
